### PR TITLE
initrd: Update submodule

### DIFF
--- a/rpm/droid-hal-discovery-img-boot.spec
+++ b/rpm/droid-hal-discovery-img-boot.spec
@@ -10,7 +10,4 @@
 
 %define lvm_root_size 4000
 
-# mkbootimg needs python
-BuildRequires:  python
-
 %include initrd/droid-hal-device-img-boot.inc

--- a/rpm/droid-hal-pioneer-img-boot.spec
+++ b/rpm/droid-hal-pioneer-img-boot.spec
@@ -10,7 +10,4 @@
 
 %define lvm_root_size 4000
 
-# mkbootimg needs python
-BuildRequires:  python
-
 %include initrd/droid-hal-device-img-boot.inc

--- a/rpm/droid-hal-voyager-img-boot.spec
+++ b/rpm/droid-hal-voyager-img-boot.spec
@@ -10,7 +10,4 @@
 
 %define lvm_root_size 4000
 
-# mkbootimg needs python
-BuildRequires:  python
-
 %include initrd/droid-hal-device-img-boot.inc


### PR DESCRIPTION
- [initrd] Add support for creating custom vendor_boot image
- [initrd] Only pull in droid-hal-tools in if needed, else use shared mkbootimg. JB#51936
- [initrd] Fix build condition for custom vendor_boot image
- [initrd] Fix USB networking in recovery on devices with multiple udc paths
- [initrd] Add option to use native kernel build. JB#62869
- [initrd] Add option to disable tools. JB#62869