### PR TITLE
initrd: Update submodule, BCB clearing

### DIFF
--- a/rpm/droid-hal-discovery-img-boot.spec
+++ b/rpm/droid-hal-discovery-img-boot.spec
@@ -4,6 +4,7 @@
 
 %define root_part_label userdata
 %define factory_part_label system_b
+%define bcb_part_path /dev/mmcblk0p64
 
 %define display_brightness_path /sys/class/leds/lcd-backlight/brightness
 %define display_brightness 16

--- a/rpm/droid-hal-pioneer-img-boot.spec
+++ b/rpm/droid-hal-pioneer-img-boot.spec
@@ -4,6 +4,7 @@
 
 %define root_part_label userdata
 %define factory_part_label system_b
+%define bcb_part_path /dev/mmcblk0p64
 
 %define display_brightness_path /sys/class/leds/lcd-backlight/brightness
 %define display_brightness 16

--- a/rpm/droid-hal-voyager-img-boot.spec
+++ b/rpm/droid-hal-voyager-img-boot.spec
@@ -4,6 +4,7 @@
 
 %define root_part_label userdata
 %define factory_part_label system_b
+%define bcb_part_path /dev/mmcblk0p64
 
 %define display_brightness_path /sys/class/leds/lcd-backlight/brightness
 %define display_brightness 16


### PR DESCRIPTION
[initrd] Add BCB clearing. JB#63708
[recovery] Start powerkey-handler earlier.
[mksfosinitrd] Do not add timestamp in gzipped rootfs. JB#60103